### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ OtherWise ,if you are using eclispe or other.this CacheFoundataion use these ext
 6. roboguice to make your application more easy and clear. use @InjectView
 7. Gson googel gson to parse json more easy and quick
 
-###More
+### More
 
 The Foundation also provide common UI like pull to refresh ,lovely toast ,base activity with swipeback and useful utility Class.
 this help you easy and quick to build a app.
@@ -37,7 +37,7 @@ Demo provide Tab + ViewPager Style.
 
 
 
-###Pics
+### Pics
 
 Pic1
 ![Alt text](1.png "Optional title")


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
